### PR TITLE
event awards csv now displays n\a for NaN values. Event rankings edge…

### DIFF
--- a/csv_modules/csv_helper.py
+++ b/csv_modules/csv_helper.py
@@ -27,9 +27,10 @@ def event_alliances_to_csv(event_name, directory):
     edges = list()
     for alliance_role in columns:
         team_col = alliances_vertex_df[alliance_role]
+        alliance_id_col = alliances_vertex_df['allianceId']
 
         new_df = pd.DataFrame({"fr_team": team_col})
-        new_df["alliance"] = alliance_role
+        new_df["alliance"] = alliance_id_col
         new_df["state_city"] = event_name[4::]
 
         edges.append(new_df)
@@ -52,6 +53,15 @@ def event_awards_to_csv(event_name, directory):
     vertex_filename = event_name + "_awards_vertex.csv"
     columns = ['eventKey', 'award', 'team', 'awardee']
     awards_vertex_df = pd.read_csv(awards_csv, names=columns)
+
+    new_awardee_values_list = list()
+    for val in awards_vertex_df['awardee']:
+        if type(val) is float:
+            new_awardee_values_list.append("n/a")
+        else:
+            new_awardee_values_list.append(val)
+
+    awards_vertex_df.update({'awardee': new_awardee_values_list})
     awards_vertex_df.to_csv(f"{directory}/{vertex_filename}")
 
     # Parse Edge

--- a/scripts/create_event_vertices_and_edges.py
+++ b/scripts/create_event_vertices_and_edges.py
@@ -1,11 +1,15 @@
 from csv_modules import event_parser
 
 
-def main():
-    event = "2015azch"
-    csv_files_directory = "/path/to/your/directory"
+def main(default_dir="../../"):
+    """ This script will output all vertex and edges csv files for the selected event to the same
+    directory under which the repository is located.
 
-    event_parser.parse_single_event_to_csv(event, csv_files_directory)
+    Args:
+        default_dir (str): Specify your own directory path or use default
+    """
+    event = "2015azch"
+    event_parser.parse_single_event_to_csv(event, default_dir)
 
 
 main()


### PR DESCRIPTION
… now use alliance id instead of alliance role. Updated create_event_vertices_and_edges to output csv file to parent the parent directory of the repository by default. User still has the option to specify their own directory